### PR TITLE
Do not auto-load DLL in chrome

### DIFF
--- a/device/vr/CMakeLists.txt
+++ b/device/vr/CMakeLists.txt
@@ -98,10 +98,10 @@ target_link_libraries(process dxgi.lib d3d11.lib d3dcompiler.lib dxguid.lib open
 set_property(TARGET process PROPERTY CXX_STANDARD 17)
 set_property(TARGET process PROPERTY CXX_STANDARD_REQUIRED ON)
 
-ADD_EXECUTABLE(add_hook WIN32 ${src} openvr/test/process3.cpp)
-target_link_libraries(add_hook dxgi.lib d3d11.lib d3dcompiler.lib dxguid.lib opengl32.lib glew32.lib glfw3.lib opencv_world420.lib)
-set_property(TARGET add_hook PROPERTY CXX_STANDARD 17)
-set_property(TARGET add_hook PROPERTY CXX_STANDARD_REQUIRED ON)
+# ADD_EXECUTABLE(add_hook WIN32 ${src} openvr/test/process3.cpp)
+# target_link_libraries(add_hook dxgi.lib d3d11.lib d3dcompiler.lib dxguid.lib opengl32.lib glew32.lib glfw3.lib opencv_world420.lib)
+# set_property(TARGET add_hook PROPERTY CXX_STANDARD 17)
+# set_property(TARGET add_hook PROPERTY CXX_STANDARD_REQUIRED ON)
 
 ADD_EXECUTABLE(native_host ${src} openvr/test/process4.cpp)
 target_link_libraries(native_host dxgi.lib d3d11.lib d3dcompiler.lib dxguid.lib opengl32.lib glew32.lib glfw3.lib opencv_world420.lib)

--- a/device/vr/build.ps1
+++ b/device/vr/build.ps1
@@ -8,8 +8,6 @@ cd mock_vr_clients\bin
 cp -Recurse -Force ..\..\..\..\..\bin\* .
 
 cp -Recurse -Force ..\..\..\..\..\Chrome-bin\* .
-rm chrome.exe
-Start-Process -FilePath "add_hook.exe" -ArgumentList "..\..\..\..\..\Chrome-bin\chrome.exe .\chrome.exe" -Wait
 
 cp -Force ..\..\..\..\..\opencv\x64\vc16\bin\opencv_world420.dll .
 


### PR DESCRIPTION
We were previously loading our DLL into chrome on start but we don't need to do this anymore if we are not looking at the DX calls.

The DLL should load automatically on openvr load, via the `VR_OVERRIDE=` environment variable path.